### PR TITLE
Add more RBAC verbs

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -37,6 +37,14 @@ var (
 		"patch",
 		"delete",
 		"deletecollection",
+		"approve",
+		"proxy",
+		"sign",
+		"attest",
+		"use",
+		"bind",
+		"impersonate",
+		"escalate",
 	}
 
 	// ValidOutputFormats is the list of valid formats for the result table.


### PR DESCRIPTION
- Including important ones to security auditing (`bind`, `impersonate`, and `escalate`).

Thinking to add more, such as https://github.com/kubernetes/kubernetes/blob/d67e6545b159658d5500f773595cc7a6b62e94ba/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani.go#L109

I'm thinking to also allow invalid verbs (maybe with a CLI flag), in case a cluster (e.g. kubernetes/kubernetes, or some customisation) has implemented some this tool doesn't know about.